### PR TITLE
Refactor to support thin jars, dependency copying, and command line args

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,3 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/tools.cli {:mvn/version "0.3.6"}}}

--- a/src/hf/depstar/core.clj
+++ b/src/hf/depstar/core.clj
@@ -13,6 +13,8 @@
     :default (cwd)]
 
    ["-o" "--output NAME" "Name of output jar"]
+
+   ["-e" "--exclude REGEX" "Exclude jars matching REGEX"]
    
    ;; A boolean option defaulting to nil
    ["-h" "--help"]])

--- a/src/hf/depstar/core.clj
+++ b/src/hf/depstar/core.clj
@@ -1,0 +1,71 @@
+(ns hf.depstar.core
+  (:require [clojure.tools.cli :refer [parse-opts]]
+            [hf.depstar.impl :refer [path cwd]]
+            [hf.depstar.uberjar :as uberjar]
+            [hf.depstar.thinjar :as thinjar]
+            [hf.depstar.deps :as deps]
+            [clojure.string :as string]))
+
+(def cli-options
+  ;; An option with a required argument
+  [["-p" "--prefix PATH" "Directory to which output should be written"
+    :parse-fn path
+    :default (cwd)]
+
+   ["-o" "--output NAME" "Name of output jar"]
+   
+   ;; A boolean option defaulting to nil
+   ["-h" "--help"]])
+
+(defn usage [options-summary]
+  (->> ["Depstar: is fully operational"
+        ""
+        "Options:"
+        options-summary
+        ""
+        "Actions:"
+        "  uberjar  Build an uberjar"
+        "  jar      Build a thin jar"
+        "  deps     Copy classpath deps to output directory"
+        ""
+        ""]
+       (string/join \newline)))
+
+(defn error-msg [errors]
+  (str "The following errors occurred while parsing your command:\n\n"
+       (string/join \newline errors)))
+
+(defn validate-args
+  [args]
+  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    (cond
+      (:help options)
+      {:exit-message (usage summary) :ok? true}
+      
+      errors 
+      {:exit-message (error-msg errors)}
+
+      (and (#{"uberjar" "jar"} (first arguments))
+           (nil? (:output options)))
+      {:exit-message (error-msg "uberjar and jar require -o / --output")}
+      
+      (and (= 1 (count arguments))
+           (#{"uberjar" "jar" "deps"} (first arguments)))
+      {:action (first arguments) :options options}
+      :else ; failed custom validation => exit with usage summary
+      {:exit-message (usage summary)})))
+
+(defn exit [status msg]
+  (println msg)
+  (System/exit status))
+
+(defn -main
+  [& args]
+
+  (let [{:keys [action options exit-message ok?]} (validate-args args)]
+    (if exit-message
+      (exit (if ok? 0 1) exit-message)
+      (case action
+        "uberjar" (uberjar/run options)
+        "jar" (thinjar/run options)
+        "deps" (deps/run options)))))

--- a/src/hf/depstar/deps.clj
+++ b/src/hf/depstar/deps.clj
@@ -1,0 +1,35 @@
+(ns hf.depstar.deps
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as jio]
+            [hf.depstar.impl :as depstar])
+  (:import (java.nio.file CopyOption LinkOption OpenOption
+                          StandardCopyOption StandardOpenOption
+                          FileSystem FileSystems Files
+                          FileVisitResult FileVisitor
+                          Path)))
+
+(derive ::depstar/jar ::preserve-jar)
+
+(defmethod depstar/copy-source*
+  ::preserve-jar
+  [src dest options]
+  (prn "copy-source* preserve-jar" src dest)
+  (let [source (depstar/path src)
+        name   (.getFileName source)
+        target (.resolve ^Path dest name)]
+    (depstar/copy! src
+                   (Files/newInputStream source (make-array OpenOption 0))
+                   target)))
+
+(defn run
+  [{:keys [prefix output] :as options}]
+  (println "Preparing deps ...")
+  (prefer-method depstar/copy-source* ::preserve-jar :hf.depstar.uberjar/consume-jar)
+  (let [dest   prefix
+        xf     (comp (remove depstar/depstar-itself?)
+                     (filter (comp #{::depstar/jar}
+                                   depstar/classify)))
+        jar-cp (into [] xf (depstar/current-classpath))]
+
+    (println "Copying deps...")
+    (run! #(depstar/copy-source % dest options) jar-cp)))

--- a/src/hf/depstar/deps.clj
+++ b/src/hf/depstar/deps.clj
@@ -13,7 +13,7 @@
 (defmethod depstar/copy-source*
   ::preserve-jar
   [src dest options]
-  (prn "copy-source* preserve-jar" src dest)
+  (println "copying from" src)
   (let [source (depstar/path src)
         name   (.getFileName source)
         target (.resolve ^Path dest name)]
@@ -22,13 +22,13 @@
                    target)))
 
 (defn run
-  [{:keys [prefix output] :as options}]
+  [{:keys [prefix output exclude] :as options}]
   (println "Preparing deps ...")
   (prefer-method depstar/copy-source* ::preserve-jar :hf.depstar.uberjar/consume-jar)
   (let [dest   prefix
-        xf     (comp (remove depstar/depstar-itself?)
-                     (filter (comp #{::depstar/jar}
-                                   depstar/classify)))
+        xf     (cond-> (comp (remove depstar/depstar-itself?)
+                             (filter (comp #{::depstar/jar} depstar/classify)))
+                 exclude (comp (remove #(re-find (re-pattern exclude) %))))
         jar-cp (into [] xf (depstar/current-classpath))]
 
     (println "Copying deps...")

--- a/src/hf/depstar/impl.clj
+++ b/src/hf/depstar/impl.clj
@@ -1,0 +1,180 @@
+(ns hf.depstar.impl
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as jio])
+  (:import (java.nio.file FileSystems FileSystem Path)
+           (java.io InputStream OutputStream PushbackReader)
+           (java.nio.file CopyOption LinkOption OpenOption
+            StandardCopyOption StandardOpenOption
+            FileSystem FileSystems Files
+            FileVisitResult FileVisitor
+            Path)
+           (java.nio.file.attribute BasicFileAttributes FileAttribute)
+           (java.util.jar JarInputStream JarOutputStream JarEntry)))
+
+(defonce ^FileSystem FS (FileSystems/getDefault))
+
+(defn path
+  ^Path [s]
+  (.getPath FS s (make-array String 0)))
+
+(defn cwd
+  ^Path []
+  (path (System/getProperty "user.dir")))
+
+(defn clash-strategy
+  [filename]
+  (cond
+    (= "data_readers.clj" filename)
+    ::merge-edn
+
+    (re-find #"^META-INF/services/" filename)
+    ::concat-lines
+
+    :else
+    ::noop))
+
+(defmulti clash (fn [filename in target]
+                  (prn {:warning "clashing jar item" :path filename})
+                  (clash-strategy filename)))
+
+(defmethod clash
+  ::merge-edn
+  [_ in target]
+  (let [er #(with-open [r (PushbackReader. %)] (edn/read r))
+        f1 (er (jio/reader in))
+        f2 (er (Files/newBufferedReader target))]
+    (with-open [w (Files/newBufferedWriter target (make-array OpenOption 0))]
+      (binding [*out* w]
+        (prn (merge f1 f2))))))
+
+(defmethod clash
+  ::concat-lines
+  [_ in target]
+  (let [f1 (line-seq (jio/reader in))
+        f2 (Files/readAllLines target)]
+    (with-open [w (Files/newBufferedWriter target (make-array OpenOption 0))]
+      (binding [*out* w]
+        (run! println (-> (vec f1)
+                          (conj "\n")
+                          (into f2)))))))
+
+(defmethod clash
+  :default
+  [_ in target]
+  ;; do nothing, first file wins
+  )
+
+(defn excluded?
+  [filename]
+  (or (#{"project.clj"
+         "LICENSE"
+         "COPYRIGHT"} filename)
+      (re-matches #"(?i)META-INF/.*\.(?:MF|SF|RSA|DSA)" filename)
+      (re-matches #"(?i)META-INF/(?:INDEX\.LIST|DEPENDENCIES|NOTICE|LICENSE)(?:\.txt)?" filename)))
+
+(defn copy!
+  ;; filename drives strategy
+  [filename ^InputStream in ^Path target]
+  (when-not (excluded? filename)
+    (if (Files/exists target (make-array LinkOption 0))
+      (clash filename in target)
+      (Files/copy in target ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0)))))
+
+(defn consume-jar
+  [^Path path f]
+  (with-open [is (-> path
+                     (Files/newInputStream (make-array OpenOption 0))
+                     java.io.BufferedInputStream.
+                     JarInputStream.)]
+    (loop []
+      (when-let [entry (.getNextJarEntry is)]
+        (f is entry)
+        (recur)))))
+
+
+(defn classify
+  [entry]
+  (let [p (path entry)
+        symlink-opts (make-array LinkOption 0)]
+    (if (Files/exists p symlink-opts)
+      (cond
+        (Files/isDirectory p symlink-opts)
+        ::directory
+
+        (and (Files/isRegularFile p symlink-opts)
+             (re-find #"\.jar$" (.toString p)))
+        ::jar
+
+        :else ::unknown)
+      ::not-found)))
+
+(defn copy-directory
+  [^Path src ^Path dest]
+  (let [copy-dir
+        (reify FileVisitor
+          (visitFile [_ p attrs]
+            (let [f (.relativize src p)]
+              (with-open [is (Files/newInputStream p (make-array OpenOption 0))]
+                (copy! (.toString f) is (.resolve dest f))))
+            FileVisitResult/CONTINUE)
+          (preVisitDirectory [_ p attrs]
+            (Files/createDirectories (.resolve dest (.relativize src p))
+                                     (make-array FileAttribute 0))
+            FileVisitResult/CONTINUE)
+          (postVisitDirectory [_ p ioexc]
+            (if ioexc (throw ioexc) FileVisitResult/CONTINUE))
+          (visitFileFailed [_ p ioexc] (throw (ex-info "Visit File Failed" {:p p} ioexc))))]
+    (Files/walkFileTree src copy-dir)
+    :ok))
+
+(defmulti copy-source*
+  (fn [src dest options]
+    (classify src)))
+
+(defmethod copy-source*
+  ::directory
+  [src dest options]
+  (copy-directory (path src) dest))
+
+(defmethod copy-source*
+  ::not-found
+  [src _dest _options]
+  (prn {:warning "could not find classpath entry" :path src}))
+
+(defn copy-source
+  [src dest options]
+  (copy-source* src dest options))
+
+(defn write-jar
+  [^Path src ^Path target]
+  (with-open [os (-> target
+                     (Files/newOutputStream (make-array OpenOption 0))
+                     JarOutputStream.)]
+    (let [walker (reify FileVisitor
+                   (visitFile [_ p attrs]
+                     (.putNextEntry os (JarEntry. (.toString (.relativize src p))))
+                     (Files/copy p os)
+                     FileVisitResult/CONTINUE)
+                   (preVisitDirectory [_ p attrs]
+                     (when (not= src p) ;; don't insert "/" to zip
+                       (.putNextEntry os (JarEntry. (str (.relativize src p) "/")))) ;; directories must end in /
+                     FileVisitResult/CONTINUE)
+                   (postVisitDirectory [_ p ioexc]
+                     (if ioexc (throw ioexc) FileVisitResult/CONTINUE))
+                   (visitFileFailed [_ p ioexc] (throw ioexc)))]
+      (Files/walkFileTree src walker)))
+  :ok)
+
+(defn current-classpath
+  []
+  (vec (.split ^String
+               (System/getProperty "java.class.path")
+               (System/getProperty "path.separator"))))
+
+(defn depstar-itself?
+  [p]
+  (re-find #"depstar" p))
+
+(defn temp-dir
+  [name]
+  (Files/createTempDirectory name (make-array FileAttribute 0)))

--- a/src/hf/depstar/thinjar.clj
+++ b/src/hf/depstar/thinjar.clj
@@ -1,0 +1,17 @@
+(ns hf.depstar.thinjar
+  (:require [hf.depstar.impl :as depstar])
+  (:import (java.nio.file Path)))
+
+(defn run
+  [{:keys [prefix output] :as options}]
+  (println "Preparing thin jar")
+  (let [tmp    (depstar/temp-dir "thinjar")
+        dest   (.resolve ^Path prefix output)
+        xf     (comp (remove depstar/depstar-itself?)
+                     (remove (comp #{::depstar/jar}
+                                   depstar/classify)))
+        jar-cp (into [] xf (depstar/current-classpath))]
+    
+    (run! #(depstar/copy-source % tmp options) jar-cp)
+    (println "Writing thinjar...")
+    (depstar/write-jar tmp dest)))

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -1,12 +1,11 @@
 (ns hf.depstar.uberjar
-  (:require [clojure.edn :as edn]
-            [clojure.java.io :as jio])
+  (:require [hf.depstar.impl :as depstar])
   (:import [java.io InputStream OutputStream PushbackReader]
            [java.nio.file CopyOption LinkOption OpenOption
-                          StandardCopyOption StandardOpenOption
-                          FileSystem FileSystems Files
-                          FileVisitResult FileVisitor
-                          Path]
+            StandardCopyOption StandardOpenOption
+            FileSystem FileSystems Files
+            FileVisitResult FileVisitor
+            Path]
            [java.nio.file.attribute BasicFileAttributes FileAttribute]
            [java.util.jar JarInputStream JarOutputStream JarEntry]))
 
@@ -15,185 +14,35 @@
 ;; clj -M options?
 ;; look into MANIFEST entries
 
-(defonce ^FileSystem FS (FileSystems/getDefault))
+(derive ::depstar/jar ::consume-jar)
 
-(defn path
-  ^Path [s]
-  (.getPath FS s (make-array String 0)))
-
-(defn clash-strategy
-  [filename]
-  (cond
-    (= "data_readers.clj" filename)
-    :merge-edn
-
-    (re-find #"^META-INF/services/" filename)
-    :concat-lines
-
-    :else
-    :noop))
-
-(defmulti clash (fn [filename in target]
-                  (prn {:warning "clashing jar item" :path filename})
-                  (clash-strategy filename)))
-
-(defmethod clash
-  :merge-edn
-  [_ in target]
-  (let [er #(with-open [r (PushbackReader. %)] (edn/read r))
-        f1 (er (jio/reader in))
-        f2 (er (Files/newBufferedReader target))]
-    (with-open [w (Files/newBufferedWriter target (make-array OpenOption 0))]
-      (binding [*out* w]
-        (prn (merge f1 f2))))))
-
-(defmethod clash
-  :concat-lines
-  [_ in target]
-  (let [f1 (line-seq (jio/reader in))
-        f2 (Files/readAllLines target)]
-    (with-open [w (Files/newBufferedWriter target (make-array OpenOption 0))]
-      (binding [*out* w]
-        (run! println (-> (vec f1)
-                          (conj "\n")
-                          (into f2)))))))
-
-(defmethod clash
-  :default
-  [_ in target]
-  ;; do nothing, first file wins
-  )
-
-(defn excluded?
-  [filename]
-  (or (#{"project.clj"
-         "LICENSE"
-         "COPYRIGHT"} filename)
-      (re-matches #"(?i)META-INF/.*\.(?:MF|SF|RSA|DSA)" filename)
-      (re-matches #"(?i)META-INF/(?:INDEX\.LIST|DEPENDENCIES|NOTICE|LICENSE)(?:\.txt)?" filename)))
-
-(defn copy!
-  ;; filename drives strategy
-  [filename ^InputStream in ^Path target]
-  (when-not (excluded? filename)
-    (if (Files/exists target (make-array LinkOption 0))
-      (clash filename in target)
-      (Files/copy in target ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0)))))
-
-(defn consume-jar
-  [^Path path f]
-  (with-open [is (-> path
-                     (Files/newInputStream (make-array OpenOption 0))
-                     java.io.BufferedInputStream.
-                     JarInputStream.)]
-    (loop []
-      (when-let [entry (.getNextJarEntry is)]
-        (f is entry)
-        (recur)))))
-
-(defn classify
-  [entry]
-  (let [p (path entry)
-        symlink-opts (make-array LinkOption 0)]
-    (if (Files/exists p symlink-opts)
-      (cond
-        (Files/isDirectory p symlink-opts)
-        :directory
-
-        (and (Files/isRegularFile p symlink-opts)
-             (re-find #"\.jar$" (.toString p)))
-        :jar
-
-        :else :unknown)
-      :not-found)))
-
-(defmulti copy-source*
-  (fn [src dest options]
-    (classify src)))
-
-(defmethod copy-source*
-  :jar
+(defmethod depstar/copy-source*
+  ::consume-jar
   [src dest options]
-  (consume-jar (path src)
-    (fn [inputstream ^JarEntry entry]
-      (let [name (.getName entry)
-            target (.resolve ^Path dest name)]
-        (if (.isDirectory entry)
-          (Files/createDirectories target (make-array FileAttribute 0))
-          (do (Files/createDirectories (.getParent target) (make-array FileAttribute 0))
-              (copy! name inputstream target)))))))
-
-(defn copy-directory
-  [^Path src ^Path dest]
-  (let [copy-dir
-        (reify FileVisitor
-          (visitFile [_ p attrs]
-            (let [f (.relativize src p)]
-              (with-open [is (Files/newInputStream p (make-array OpenOption 0))]
-                (copy! (.toString f) is (.resolve dest f))))
-            FileVisitResult/CONTINUE)
-          (preVisitDirectory [_ p attrs]
-            (Files/createDirectories (.resolve dest (.relativize src p))
-                                     (make-array FileAttribute 0))
-            FileVisitResult/CONTINUE)
-          (postVisitDirectory [_ p ioexc]
-            (if ioexc (throw ioexc) FileVisitResult/CONTINUE))
-          (visitFileFailed [_ p ioexc] (throw (ex-info "Visit File Failed" {:p p} ioexc))))]
-    (Files/walkFileTree src copy-dir)
-    :ok))
-
-(defmethod copy-source*
-  :directory
-  [src dest options]
-  (copy-directory (path src) dest))
-
-(defmethod copy-source*
-  :not-found
-  [src _dest _options]
-  (prn {:warning "could not find classpath entry" :path src}))
-
-(defn copy-source
-  [src dest options]
-  (copy-source* src dest options))
-
-(defn write-jar
-  [^Path src ^Path target]
-  (with-open [os (-> target
-                     (Files/newOutputStream (make-array OpenOption 0))
-                     JarOutputStream.)]
-    (let [walker (reify FileVisitor
-                   (visitFile [_ p attrs]
-                     (.putNextEntry os (JarEntry. (.toString (.relativize src p))))
-                     (Files/copy p os)
-                     FileVisitResult/CONTINUE)
-                   (preVisitDirectory [_ p attrs]
-                     (when (not= src p) ;; don't insert "/" to zip
-                       (.putNextEntry os (JarEntry. (str (.relativize src p) "/")))) ;; directories must end in /
-                     FileVisitResult/CONTINUE)
-                   (postVisitDirectory [_ p ioexc]
-                     (if ioexc (throw ioexc) FileVisitResult/CONTINUE))
-                   (visitFileFailed [_ p ioexc] (throw ioexc)))]
-      (Files/walkFileTree src walker)))
-  :ok)
-
-(defn current-classpath
-  []
-  (vec (.split ^String
-               (System/getProperty "java.class.path")
-               (System/getProperty "path.separator"))))
-
-(defn depstar-itself?
-  [p]
-  (re-find #"depstar" p))
+  (prn "copy-source* consume-jar" src dest)
+  (depstar/consume-jar
+   (depstar/path src)
+   (fn [inputstream ^JarEntry entry]
+     (let [name (.getName entry)
+           target (.resolve ^Path dest name)]
+       (if (.isDirectory entry)
+         (Files/createDirectories target (make-array FileAttribute 0))
+         (do (Files/createDirectories (.getParent target) (make-array FileAttribute 0))
+             (depstar/copy! name inputstream target)))))))
 
 (defn run
-  [{:keys [dest] :as options}]
-  (let [tmp (Files/createTempDirectory "uberjar" (make-array FileAttribute 0))
-        cp (into [] (remove depstar-itself?) (current-classpath))]
-    (run! #(copy-source % tmp options) cp)
-    (println "Writing jar...")
-    (write-jar tmp (path dest))))
+  [{:keys [prefix output] :as options}]
+  (prefer-method depstar/copy-source*  ::consume-jar :hf.depstar.deps/preserve-jar)
+  (println "Preparing uberjar")
+  (let [tmp (depstar/temp-dir "uberjar")
+        xf (remove depstar/depstar-itself?)
+        cp (into [] xf (depstar/current-classpath))
+        dest (-> prefix
+                 (.resolve ^Path output))]
+    (run! #(depstar/copy-source % tmp options) cp)
+    (println "Writing uberjar...")
+    (depstar/write-jar tmp dest)))
 
-(defn -main
-  [destination]
-  (run {:dest destination}))
+;; backwards compatibility ...
+(defn -main [destination]
+  (run {:prefix (depstar/cwd) :output (depstar/path destination)}))

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -19,7 +19,7 @@
 (defmethod depstar/copy-source*
   ::consume-jar
   [src dest options]
-  (prn "copy-source* consume-jar" src dest)
+  (println "copying from" src)
   (depstar/consume-jar
    (depstar/path src)
    (fn [inputstream ^JarEntry entry]
@@ -31,11 +31,12 @@
              (depstar/copy! name inputstream target)))))))
 
 (defn run
-  [{:keys [prefix output] :as options}]
+  [{:keys [prefix output exclude] :as options}]
   (prefer-method depstar/copy-source*  ::consume-jar :hf.depstar.deps/preserve-jar)
   (println "Preparing uberjar")
   (let [tmp (depstar/temp-dir "uberjar")
-        xf (remove depstar/depstar-itself?)
+        xf (cond-> (remove depstar/depstar-itself?)
+             exclude (comp (remove #(re-find (re-pattern exclude) %))))
         cp (into [] xf (depstar/current-classpath))
         dest (-> prefix
                  (.resolve ^Path output))]


### PR DESCRIPTION
Howdy. This is kinda large for a PR, and maybe has a lot of things you'd like changed, but I thought it was ready for someone to poke at :)

I had a need for the ability to make a thin jar, as well as the ability to copy all the jar dependencies out of a classpath (building a Kafka Connector, which wants things laid out like this). 

So one way to think about this is that the `jar` argument emulates `lein jar` and the `deps` argument emulates `lein libdir` (see [lein-libdir](https://github.com/djpowell/lein-libdir))
