### PR TITLE
Add manifest/main/running example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ Then invoke `depstar` with the chosen aliases:
 clj -A:depstar:webassets -m hf.depstar.uberjar MyProject.jar
 ```
 
+Note that the resulting uberjar does not contain a manifest file so it cannot be run directly. `depstar` does no AOT compilation
+either, so it's likely the only `-main` you'll have in the uberjar is `clojure.main/-main` -- but you can use that to run your own
+code's `-main`. Create a file, `main.mf`, containing:
+
+```
+Main-Class: clojure.main
+```
+
+Now you can add this to the `MyProject.jar` you created above:
+
+```bash
+jar ufm MyProject.jar main.mf
+```
+
+If you now run the uberjar without command-line arguments, you'll get `clojure.main`'s REPL:
+
+```bash
+java -jar MyProject.jar
+...
+user=>
+```
+
+If your main namespace is `project.core`, you can run that as follows:
+
+```bash
+java -jar MyProject.jar -m project.core
+```
+
 # License
 
 The use and distribution terms for this software are covered by the


### PR DESCRIPTION
Clarifies that `depstar` does no AOT and does not include a `MANIFEST.MF` file. Then shows how to create and add a manifest that points to Clojure's default main entry point and how to run your own project namespace via `-m`.