### PR TITLE
Fix healthfinch/depstar#4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 .java-version
 .cpcache
+*.jar
+/target

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install this tool to an alias in `$PROJECT/deps.edn` or `$HOME/.clojure/deps.edn
 {
   :aliases {:depstar
               {:extra-deps
-                 {seancorfield/depstar {:mvn/version "0.1.3"}}}}
+                 {seancorfield/depstar {:mvn/version "0.1.4"}}}}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./depstar_logo.png" />
 
-a clj-based uberjarrer
+a clj-based uberjarrer (forked from [healthfinch/depstar](https://github.com/healthfinch/depstar) and enhanced)
 
 # Usage
 
@@ -12,8 +12,8 @@ Install this tool to an alias in `$PROJECT/deps.edn` or `$HOME/.clojure/deps.edn
 {
   :aliases {:depstar
               {:extra-deps
-                 {com.healthfinch/depstar {:git/url "https://github.com/healthfinch/depstar.git"
-                                           :sha "4aa7b35189693feebc7d7e4a180b8af0326c9164"}}}}
+                 {seancorfield/depstar {:git/url "https://github.com/seancorfield/depstar.git"
+                                        :sha "22859a04cc99ce38c391a569b771e8a65afa6aad"}}}}
 }
 ```
 
@@ -21,6 +21,12 @@ Create an uberjar by invoking `depstar` with the desired jar name:
 
 ```bash
 clj -A:depstar -m hf.depstar.uberjar MyProject.jar
+```
+
+Create a (library) jar by invoking `depstar` with the desired jar name:
+
+```bash
+clj -A:depstar -m hf.depstar.jar MyLib.jar
 ```
 
 `depstar` uses the classpath computed by `clj`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install this tool to an alias in `$PROJECT/deps.edn` or `$HOME/.clojure/deps.edn
 {
   :aliases {:depstar
               {:extra-deps
-                 {seancorfield/depstar {:mvn/version "0.1.4"}}}}
+                 {seancorfield/depstar {:mvn/version "0.1.5"}}}}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install this tool to an alias in `$PROJECT/deps.edn` or `$HOME/.clojure/deps.edn
   :aliases {:depstar
               {:extra-deps
                  {seancorfield/depstar {:git/url "https://github.com/seancorfield/depstar.git"
-                                        :sha "22859a04cc99ce38c391a569b771e8a65afa6aad"}}}}
+                                        :sha "10d25e6e8e81bfaaf96002e9cce675772d60a356"}}}}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install this tool to an alias in `$PROJECT/deps.edn` or `$HOME/.clojure/deps.edn
 {
   :aliases {:depstar
               {:extra-deps
-                 {seancorfield/depstar {:mvn/version "0.1.2"}}}}
+                 {seancorfield/depstar {:mvn/version "0.1.3"}}}}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Install this tool to an alias in `$PROJECT/deps.edn` or `$HOME/.clojure/deps.edn
 {
   :aliases {:depstar
               {:extra-deps
-                 {seancorfield/depstar {:git/url "https://github.com/seancorfield/depstar.git"
-                                        :sha "10d25e6e8e81bfaaf96002e9cce675772d60a356"}}}}
+                 {seancorfield/depstar {:mvn/version "0.1.2"}}}}
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   </developers>
 
   <scm>
-    <url>https://github.com/seancorfield/depstar</url>
     <connection>scm:git:git@github.com:seancorfield/depstar.git</connection>
     <developerConnection>scm:git:git@github.com:seancorfield/depstar.git</developerConnection>
     <url>git@github.com:seancorfield/depstar.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>seancorfield</groupId>
   <artifactId>depstar</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <name>depstar</name>
 
   <description>a clj-based uberjarrer</description>
@@ -27,8 +27,8 @@
   <scm>
     <connection>scm:git:git@github.com:seancorfield/depstar.git</connection>
     <developerConnection>scm:git:git@github.com:seancorfield/depstar.git</developerConnection>
-    <url>git@github.com:seancorfield/depstar.git</url>
-    <tag>b8736f14204a63ba089395eb6f2e26656e0b36b5</tag>
+    <url>https://github.com/seancorfield/depstar</url>
+    <tag>1268cc280221aa6171b35a68f9a64d22cb4904ab</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>seancorfield</groupId>
   <artifactId>depstar</artifactId>
-  <version>0.1.4</version>
+  <version>0.1.5</version>
   <name>depstar</name>
 
   <description>a clj-based uberjarrer</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,17 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>seancorfield</groupId>
   <artifactId>depstar</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <name>depstar</name>
+
+  <description>a clj-based uberjarrer</description>
+  <url>https://github.com/seancorfield/depstar</url>
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+    </license>
+  </licenses>
 
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>seancorfield</groupId>
   <artifactId>depstar</artifactId>
-  <version>0.1.2</version>
+  <version>0.1.3</version>
   <name>depstar</name>
 
   <description>a clj-based uberjarrer</description>
@@ -25,10 +25,11 @@
   </developers>
 
   <scm>
+    <url>https://github.com/seancorfield/depstar</url>
     <connection>scm:git:git@github.com:seancorfield/depstar.git</connection>
     <developerConnection>scm:git:git@github.com:seancorfield/depstar.git</developerConnection>
     <url>git@github.com:seancorfield/depstar.git</url>
-    <tag>HEAD</tag>
+    <tag>b8736f14204a63ba089395eb6f2e26656e0b36b5</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <connection>scm:git:git@github.com:seancorfield/depstar.git</connection>
     <developerConnection>scm:git:git@github.com:seancorfield/depstar.git</developerConnection>
     <url>https://github.com/seancorfield/depstar</url>
-    <tag>7077311fea867c30b8e21357afd1a8bfc6a422c9</tag>
+    <tag>905f79fd1641b39f9c94901bdddd923cb1945f94</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>seancorfield</groupId>
   <artifactId>depstar</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <name>depstar</name>
 
   <description>a clj-based uberjarrer</description>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <connection>scm:git:git@github.com:seancorfield/depstar.git</connection>
     <developerConnection>scm:git:git@github.com:seancorfield/depstar.git</developerConnection>
     <url>https://github.com/seancorfield/depstar</url>
-    <tag>1268cc280221aa6171b35a68f9a64d22cb4904ab</tag>
+    <tag>7077311fea867c30b8e21357afd1a8bfc6a422c9</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>seancorfield</groupId>
+  <artifactId>depstar</artifactId>
+  <version>0.1.0</version>
+  <name>depstar</name>
+
+  <developers>
+    <developer>
+      <name>Ghadi Shayban</name>
+    </developer>
+    <developer>
+      <name>Sean Corfield</name>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:seancorfield/depstar.git</connection>
+    <developerConnection>scm:git:git@github.com:seancorfield/depstar.git</developerConnection>
+    <url>git@github.com:seancorfield/depstar.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>clojure</artifactId>
+      <version>1.9.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>clojars</id>
+      <url>https://repo.clojars.org/</url>
+    </repository>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </distributionManagement>
+
+</project>

--- a/src/hf/depstar/jar.clj
+++ b/src/hf/depstar/jar.clj
@@ -1,0 +1,6 @@
+(ns hf.depstar.jar
+  (:require [hf.depstar.uberjar :refer [run]]))
+
+(defn -main
+  [destination]
+  (run {:dest destination :jar :thin}))

--- a/src/hf/depstar/specs.clj
+++ b/src/hf/depstar/specs.clj
@@ -15,7 +15,8 @@
 (s/fdef u/copy!
         :args (s/cat :f ::filename
                      :i #(instance? java.io.InputStream %)
-                     :target ::path))
+                     :target ::path
+                     :last-mod (s/? inst?)))
 
 (s/fdef u/consume-jar
         :args (s/cat :p ::path

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -60,9 +60,8 @@
 
 (defmethod clash
   :default
-  [_ in target]
+  [_ in target])
   ;; do nothing, first file wins
-  )
 
 (defn excluded?
   [filename]
@@ -114,14 +113,15 @@
 (defmethod copy-source*
   :jar
   [src dest options]
-  (consume-jar (path src)
-    (fn [inputstream ^JarEntry entry]
-      (let [name (.getName entry)
-            target (.resolve ^Path dest name)]
-        (if (.isDirectory entry)
-          (Files/createDirectories target (make-array FileAttribute 0))
-          (do (Files/createDirectories (.getParent target) (make-array FileAttribute 0))
-              (copy! name inputstream target)))))))
+  (when-not (= :thin (:jar options))
+    (consume-jar (path src)
+      (fn [inputstream ^JarEntry entry]
+        (let [name (.getName entry)
+              target (.resolve ^Path dest name)]
+          (if (.isDirectory entry)
+            (Files/createDirectories target (make-array FileAttribute 0))
+            (do (Files/createDirectories (.getParent target) (make-array FileAttribute 0))
+                (copy! name inputstream target))))))))
 
 (defn copy-directory
   [^Path src ^Path dest]

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -187,11 +187,11 @@
   (re-find #"depstar" p))
 
 (defn run
-  [{:keys [dest] :as options}]
+  [{:keys [dest jar] :or {jar :uber} :as options}]
   (let [tmp (Files/createTempDirectory "uberjar" (make-array FileAttribute 0))
         cp (into [] (remove depstar-itself?) (current-classpath))]
     (run! #(copy-source % tmp options) cp)
-    (println "Writing jar...")
+    (println "Writing" (name jar) "jar:" dest)
     (write-jar tmp (path dest))))
 
 (defn -main

--- a/src/hf/depstar/uberjar.clj
+++ b/src/hf/depstar/uberjar.clj
@@ -87,7 +87,7 @@
                      java.io.BufferedInputStream.
                      JarInputStream.)]
     (loop []
-      (when-let [entry (.getNextJarEntry is)]
+      (when-let [entry (try (.getNextJarEntry is) (catch Exception _))]
         (f is entry)
         (recur)))))
 


### PR DESCRIPTION
Treats exceptions from `.getNextJarEntry` as EOF which has seemed to be safe in my experience with a patched version of `depstar`.